### PR TITLE
Using exactly version 1.2.3 of showdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "commander": ">= 0.4.0",
     "handlebars": ">= 1.0.1",
-    "showdown": "^1.1.0",
+    "showdown": "=1.2.3",
     "wrench": ">= 1.3.2"
   },
   "bin": {


### PR DESCRIPTION
Because the new version of showdown is not work.
